### PR TITLE
Fix Laplacian smoothing demo formatting

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,4 +1,4 @@
-name: Build Movement
+name: 'Run Movement test suite'
 
 on:
   # Run test suite whenever main is updated
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: "Build Movement"
+    name: 'Test suite'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # The docker container to use.
@@ -24,28 +24,34 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v2
-      - name: Cleanup
+
+      - name: 'Cleanup'
         if: ${{ always() }}
         run: |
           cd ..
           rm -rf build
-      - name: Setup python
+
+      - name: 'Setup python'
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install
+
+      - name: 'Install Movement'
         run: |
           . /home/firedrake/firedrake/bin/activate
           python -m pip install -e .
-      - name: Test
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          python $(which firedrake-clean)
-          python -m coverage erase
-          python -m coverage run --source=movement -m pytest -v --durations=20 test
-          python -m coverage report
-      - name: Lint
+
+      - name: 'Lint'
         if: ${{ always() }}
         run: |
           . /home/firedrake/firedrake/bin/activate
           make lint
+
+      - name: 'Test Animate'
+        run: |
+          . /home/firedrake/firedrake/bin/activate
+          export GITHUB_ACTIONS_TEST_RUN=1
+          python $(which firedrake-clean)
+          python -m coverage erase
+          python -m coverage run --source=movement -m pytest -v --durations=20 test
+          python -m coverage report

--- a/demos/laplacian_smoothing.py
+++ b/demos/laplacian_smoothing.py
@@ -10,17 +10,17 @@
 #
 # where :math:`\mathbf{v}` is the so-called *mesh velocity* that we solve for. Note that
 # the derivatives in the Laplace equation are in terms of the *computational coordinates*
-# :math:`\boldsymbol{\xi}}`, rather than the physical coordinates :math:`\mathbf{x}`.
+# :math:`\boldsymbol{\xi}`, rather than the physical coordinates :math:`\mathbf{x}`.
 #
 # With the mesh velocity, we update the physical coordinates according to
 #
 # .. math::
-#    \mathbf{x} := \mathbf{x} + \mathbf{v} * \Delta t,
+#    \mathbf{x} := \mathbf{x} + \mathbf{v} \Delta t,
 #
 # where :math:`\Delta t` is the timestep.
 #
 # To motivate why we might want to take this sort of approach, consider momentarily the
-# 1D case, where we have velocities :math:`\{v_i\}_{i=1}^n at each of a sequence of
+# 1D case, where we have velocities :math:`\{v_i\}_{i=1}^n` at each of a sequence of
 # :math:`n\in\mathbb{N}` points with uniform separation :math:`h`. If we want to smooth
 # out the local variation in the velocities in the vicinity of :math:`v_i, we might
 # consider averaging out :math:`(v_{i-1}-v_i)/h` and :math:`(v_{i+1}-v_i)/h`. Doing so

--- a/demos/laplacian_smoothing.py
+++ b/demos/laplacian_smoothing.py
@@ -22,7 +22,7 @@
 # To motivate why we might want to take this sort of approach, consider momentarily the
 # 1D case, where we have velocities :math:`\{v_i\}_{i=1}^n` at each of a sequence of
 # :math:`n\in\mathbb{N}` points with uniform separation :math:`h`. If we want to smooth
-# out the local variation in the velocities in the vicinity of :math:`v_i, we might
+# out the local variation in the velocities in the vicinity of :math:`v_i`, we might
 # consider averaging out :math:`(v_{i-1}-v_i)/h` and :math:`(v_{i+1}-v_i)/h`. Doing so
 # gives
 #


### PR DESCRIPTION
Closes #69.
Closes #75.

It seems we missed some LaTeX errors in the Laplacian smoothing demo, which are fixed here. This PR also makes the linting check happen before testing in the CI so that we catch formatting issues sooner.