### PR TITLE
Option for raising warning if not converged

### DIFF
--- a/movement/laplacian_smoothing.py
+++ b/movement/laplacian_smoothing.py
@@ -1,4 +1,5 @@
 import firedrake
+import firedrake.exceptions as fexc
 import numpy as np
 import ufl
 from firedrake.petsc import PETSc
@@ -86,7 +87,10 @@ class LaplacianSmoother(PrimeMover):
 
         # Solve on computational mesh
         self.mesh.coordinates.assign(self.xi)
-        self._solver.solve()
+        try:
+            self._solver.solve()
+        except fexc.ConvergenceError as conv_err:
+            self._convergence_error(exception=conv_err)
 
         # Update mesh coordinates
         self.displacement[:] = self.v.dat.data_with_halos * self.dt

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -262,7 +262,10 @@ class SpringMover_Lineal(SpringMover_Base):
 
         # Assemble and solve the linear system
         K = self.assemble_stiffness_matrix(boundary_conditions=boundary_conditions)
-        self.displacement = np.linalg.solve(K, self._forcing.flatten()) * self.dt
+        try:
+            self.displacement = np.linalg.solve(K, self._forcing.flatten()) * self.dt
+        except Exception as conv_err:
+            self._convergence_error(exception=conv_err)
 
         # Update mesh coordinates
         shape = self.mesh.coordinates.dat.data_with_halos.shape

--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -167,14 +167,16 @@ class TestMongeAmpere(unittest.TestCase):
             mover.move()
         self.assertEqual(str(cm.exception), "Failed to converge in 1 iteration.")
 
-    def test_divergence_convergenceerror(self):
+    @parameterized.expand([(True,), (False,)])
+    def test_divergence_convergenceerror(self, raise_errors):
         """
-        Test that the mesh mover raises a :class:`~.ConvergenceError` if it diverges.
+        Test that divergence of the mesh mover raises a :class:`~.ConvergenceError` if
+        `raise_errors=True` and a :class:`~.Warning` otherwise.
         """
         mesh = self.mesh(2, n=4)
         mover = MongeAmpereMover_Relaxation(mesh, ring_monitor, dtol=1.0e-08)
-        with self.assertRaises(ConvergenceError) as cm:
-            mover.move()
+        with self.assertRaises(ConvergenceError if raise_errors else Warning) as cm:
+            mover.move(raise_errors=raise_errors)
         self.assertEqual(str(cm.exception), "Diverged after 1 iteration.")
 
     def test_initial_guess_valueerror(self):

--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -165,7 +165,7 @@ class TestMongeAmpere(unittest.TestCase):
         mover = MongeAmpereMover(mesh, ring_monitor, method=method, maxiter=1)
         with self.assertRaises(ConvergenceError) as cm:
             mover.move()
-        self.assertEqual(str(cm.exception), "Failed to converge in 1 iteration.")
+        self.assertEqual(str(cm.exception), "Solver failed to converge in 1 iteration.")
 
     @parameterized.expand([(True,), (False,)])
     def test_divergence_convergenceerror(self, raise_errors):
@@ -174,10 +174,12 @@ class TestMongeAmpere(unittest.TestCase):
         `raise_errors=True` and a :class:`~.Warning` otherwise.
         """
         mesh = self.mesh(2, n=4)
-        mover = MongeAmpereMover_Relaxation(mesh, ring_monitor, dtol=1.0e-08)
+        mover = MongeAmpereMover_Relaxation(
+            mesh, ring_monitor, dtol=1.0e-08, raise_convergence_errors=raise_errors
+        )
         with self.assertRaises(ConvergenceError if raise_errors else Warning) as cm:
-            mover.move(raise_errors=raise_errors)
-        self.assertEqual(str(cm.exception), "Diverged after 1 iteration.")
+            mover.move()
+        self.assertEqual(str(cm.exception), "Solver diverged after 1 iteration.")
 
     def test_initial_guess_valueerror(self):
         mesh = self.mesh(2, n=2)


### PR DESCRIPTION
Closes #86.

Does this option look like what you were asking for @erizmr?

We could make it more general and support it for all methods but I thought I'd just introduce it as a kwarg for `move` in the Monge-Ampere case for now.