### PR TITLE
Separate out diagnostics

### DIFF
--- a/demos/laplacian_smoothing.py
+++ b/demos/laplacian_smoothing.py
@@ -141,8 +141,6 @@ for i, time in enumerate(times):
         update_boundary_velocity=update_boundary_velocity,
         boundary_conditions=boundary_conditions,
     )
-    displacement = np.linalg.norm(mover.displacement)
-    print(f"time = {time:.1f} s, displacement = {displacement:.2f} m")
 
     # Plot the current mesh, adding a time label
     ax = axes[idx // 4, idx % 4]

--- a/demos/laplacian_smoothing.py
+++ b/demos/laplacian_smoothing.py
@@ -150,6 +150,22 @@ for i, time in enumerate(times):
 axes[0, 1].axis(False)
 plt.savefig("laplacian_smoothing-adapted_meshes.jpg")
 
+# This should give command line output similar to the following:
+#
+# .. code-block:: none
+#
+#    0.00 s   Volume ratio  1.00   Variation (σ/μ) 5.16e-16   Displacement 0.00 m
+#    0.10 s   Volume ratio  1.03   Variation (σ/μ) 7.35e-03   Displacement 0.04 m
+#    0.20 s   Volume ratio  1.08   Variation (σ/μ) 1.90e-02   Displacement 0.06 m
+#    0.30 s   Volume ratio  1.13   Variation (σ/μ) 3.04e-02   Displacement 0.06 m
+#    0.40 s   Volume ratio  1.17   Variation (σ/μ) 3.73e-02   Displacement 0.04 m
+#    0.50 s   Volume ratio  1.17   Variation (σ/μ) 3.73e-02   Displacement 0.00 m
+#    0.60 s   Volume ratio  1.13   Variation (σ/μ) 3.04e-02   Displacement 0.04 m
+#    0.70 s   Volume ratio  1.08   Variation (σ/μ) 1.90e-02   Displacement 0.06 m
+#    0.80 s   Volume ratio  1.03   Variation (σ/μ) 7.35e-03   Displacement 0.06 m
+#    0.90 s   Volume ratio  1.00   Variation (σ/μ) 1.34e-10   Displacement 0.04 m
+#    1.00 s   Volume ratio  1.00   Variation (σ/μ) 1.34e-10   Displacement 0.00 m
+#
 # .. figure:: laplacian_smoothing-adapted_meshes.jpg
 #    :figwidth: 100%
 #    :align: center

--- a/demos/lineal_spring.py
+++ b/demos/lineal_spring.py
@@ -167,6 +167,22 @@ for i, time in enumerate(times):
 axes[0, 1].axis(False)
 plt.savefig("lineal_spring-adapted_meshes.jpg")
 
+# This should give command line output similar to the following:
+#
+# .. code-block:: none
+#
+#    0.00   Volume ratio  1.00   Variation (σ/μ) 5.16e-16   Displacement 0.00 m
+#    0.10   Volume ratio  1.02   Variation (σ/μ) 4.23e-03   Displacement 0.05 m
+#    0.20   Volume ratio  1.05   Variation (σ/μ) 1.11e-02   Displacement 0.08 m
+#    0.30   Volume ratio  1.09   Variation (σ/μ) 1.82e-02   Displacement 0.08 m
+#    0.40   Volume ratio  1.11   Variation (σ/μ) 2.27e-02   Displacement 0.05 m
+#    0.50   Volume ratio  1.11   Variation (σ/μ) 2.27e-02   Displacement 0.00 m
+#    0.60   Volume ratio  1.09   Variation (σ/μ) 1.81e-02   Displacement 0.05 m
+#    0.70   Volume ratio  1.05   Variation (σ/μ) 1.08e-02   Displacement 0.08 m
+#    0.80   Volume ratio  1.02   Variation (σ/μ) 3.82e-03   Displacement 0.08 m
+#    0.90   Volume ratio  1.01   Variation (σ/μ) 1.32e-03   Displacement 0.05 m
+#    1.00   Volume ratio  1.01   Variation (σ/μ) 1.32e-03   Displacement 0.00 m
+#
 # .. figure:: lineal_spring-adapted_meshes.jpg
 #    :figwidth: 100%
 #    :align: center

--- a/demos/lineal_spring.py
+++ b/demos/lineal_spring.py
@@ -158,8 +158,6 @@ for i, time in enumerate(times):
         update_boundary_displacement=update_boundary_displacement,
         boundary_conditions=boundary_conditions,
     )
-    displacement = np.linalg.norm(mover.displacement)
-    print(f"time = {time:.1f} s, displacement = {displacement:.2f} m")
 
     # Plot the current mesh, adding a time label
     ax = axes[idx // 4, idx % 4]

--- a/demos/monge_ampere1.py
+++ b/demos/monge_ampere1.py
@@ -102,6 +102,65 @@ rtol = 1.0e-03 if test else 1.0e-08
 mover = MongeAmpereMover(mesh, ring_monitor, method="quasi_newton", rtol=rtol)
 mover.move()
 
+# This should give command line output similar to the following:
+#
+# .. code-block:: none
+#
+#       0   Volume ratio 11.49   Variation (σ/μ) 9.71e-01   Residual 9.39e-01
+#       1   Volume ratio  8.32   Variation (σ/μ) 6.84e-01   Residual 5.35e-01
+#       2   Volume ratio  5.74   Variation (σ/μ) 5.55e-01   Residual 3.83e-01
+#       3   Volume ratio  6.86   Variation (σ/μ) 4.92e-01   Residual 3.06e-01
+#       4   Volume ratio  5.91   Variation (σ/μ) 4.53e-01   Residual 2.69e-01
+#       5   Volume ratio  8.38   Variation (σ/μ) 4.20e-01   Residual 2.22e-01
+#       6   Volume ratio  7.34   Variation (σ/μ) 4.12e-01   Residual 2.14e-01
+#       7   Volume ratio  7.68   Variation (σ/μ) 4.02e-01   Residual 2.03e-01
+#       8   Volume ratio  7.93   Variation (σ/μ) 3.84e-01   Residual 1.84e-01
+#       9   Volume ratio  7.81   Variation (σ/μ) 3.83e-01   Residual 1.86e-01
+#      10   Volume ratio  7.60   Variation (σ/μ) 3.93e-01   Residual 1.97e-01
+#      11   Volume ratio  7.99   Variation (σ/μ) 4.14e-01   Residual 2.13e-01
+#      12   Volume ratio  8.22   Variation (σ/μ) 4.21e-01   Residual 2.20e-01
+#      13   Volume ratio 10.79   Variation (σ/μ) 4.54e-01   Residual 2.13e-01
+#      14   Volume ratio  9.66   Variation (σ/μ) 4.15e-01   Residual 1.33e-01
+#      15   Volume ratio 10.52   Variation (σ/μ) 3.75e-01   Residual 9.77e-02
+#      16   Volume ratio 10.00   Variation (σ/μ) 3.90e-01   Residual 8.64e-02
+#      17   Volume ratio  9.00   Variation (σ/μ) 3.61e-01   Residual 6.33e-02
+#      18   Volume ratio  9.53   Variation (σ/μ) 3.73e-01   Residual 4.41e-02
+#      19   Volume ratio  8.86   Variation (σ/μ) 3.60e-01   Residual 3.71e-02
+#      20   Volume ratio  9.38   Variation (σ/μ) 3.65e-01   Residual 2.71e-02
+#      21   Volume ratio  8.95   Variation (σ/μ) 3.57e-01   Residual 2.23e-02
+#      22   Volume ratio  9.15   Variation (σ/μ) 3.57e-01   Residual 1.32e-02
+#      23   Volume ratio  8.90   Variation (σ/μ) 3.52e-01   Residual 8.93e-03
+#      24   Volume ratio  8.87   Variation (σ/μ) 3.50e-01   Residual 3.93e-03
+#      25   Volume ratio  8.80   Variation (σ/μ) 3.48e-01   Residual 2.61e-03
+#      26   Volume ratio  8.85   Variation (σ/μ) 3.49e-01   Residual 1.51e-03
+#      27   Volume ratio  8.83   Variation (σ/μ) 3.48e-01   Residual 1.15e-03
+#      28   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 7.98e-04
+#      29   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 6.27e-04
+#      30   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 4.46e-04
+#      31   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 3.46e-04
+#      32   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 2.39e-04
+#      33   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 1.77e-04
+#      34   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 1.14e-04
+#      35   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 7.82e-05
+#      36   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 4.69e-05
+#      37   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 2.96e-05
+#      38   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 1.77e-05
+#      39   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 1.11e-05
+#      40   Volume ratio  8.85   Variation (σ/μ) 3.48e-01   Residual 7.43e-06
+#      41   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 5.07e-06
+#      42   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 3.86e-06
+#      43   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 2.85e-06
+#      44   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 2.30e-06
+#      45   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 1.72e-06
+#      46   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 1.38e-06
+#      47   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 9.75e-07
+#      48   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 7.42e-07
+#      49   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 4.50e-07
+#      50   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 3.00e-07
+#      51   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 1.42e-07
+#      52   Volume ratio  8.84   Variation (σ/μ) 3.48e-01   Residual 7.93e-08
+#    Solver converged in 52 iterations.
+#
 # The adapted mesh can be accessed via the `mesh` attribute of the mover. Plotting it,
 # we see that the adapted mesh has its resolution focused around a ring, as expected.
 

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -142,30 +142,30 @@ mover = MongeAmpereMover(mesh, monitor, method="quasi_newton", rtol=rtol)
 mover.move()
 
 # For every iteration the MongeAmpereMover prints the minimum to maximum ratio of
-# the cell areas in the mesh, the residual in the Monge Ampere equation, and the
+# the cell areas in the mesh, the residual in the Monge-Ampère equation, and the
 # coefficient of variation of the cell areas:
 #
 # .. code-block:: none
 #
-#    0   Min/Max 2.0268e-01   Residual 4.7659e-01   Variation (σ/μ) 9.9384e-01
-#    1   Min/Max 3.7852e-01   Residual 2.4133e-01   Variation (σ/μ) 9.9659e-01
-#    2   Min/Max 5.9791e-01   Residual 1.2442e-01   Variation (σ/μ) 9.9774e-01
-#    3   Min/Max 7.1000e-01   Residual 6.5811e-02   Variation (σ/μ) 9.9804e-01
-#    4   Min/Max 7.7704e-01   Residual 3.4929e-02   Variation (σ/μ) 9.9818e-01
-#    5   Min/Max 8.3434e-01   Residual 1.7261e-02   Variation (σ/μ) 9.9829e-01
-#    6   Min/Max 8.5805e-01   Residual 7.7528e-03   Variation (σ/μ) 9.9833e-01
-#    7   Min/Max 8.6653e-01   Residual 3.1551e-03   Variation (σ/μ) 9.9835e-01
-#    8   Min/Max 8.6796e-01   Residual 1.1644e-03   Variation (σ/μ) 9.9835e-01
-#    9   Min/Max 8.6792e-01   Residual 3.8816e-04   Variation (σ/μ) 9.9835e-01
-#   10   Min/Max 8.6784e-01   Residual 1.1574e-04   Variation (σ/μ) 9.9835e-01
-#   11   Min/Max 8.6778e-01   Residual 1.5645e-05   Variation (σ/μ) 9.9835e-01
-#   12   Min/Max 8.6776e-01   Residual 7.5654e-06   Variation (σ/μ) 9.9835e-01
-#   13   Min/Max 8.6776e-01   Residual 3.5803e-06   Variation (σ/μ) 9.9835e-01
-#   14   Min/Max 8.6775e-01   Residual 1.5113e-06   Variation (σ/μ) 9.9835e-01
-#   15   Min/Max 8.6775e-01   Residual 5.7080e-07   Variation (σ/μ) 9.9835e-01
-#   16   Min/Max 8.6775e-01   Residual 1.9357e-07   Variation (σ/μ) 9.9835e-01
-#   17   Min/Max 8.6775e-01   Residual 5.8585e-08   Variation (σ/μ) 9.9835e-01
-#   Converged in 17 iterations.
+#       0   Volume ratio  4.93   Variation (σ/μ) 4.73e-01   Residual 4.77e-01
+#       1   Volume ratio  2.64   Variation (σ/μ) 2.44e-01   Residual 2.41e-01
+#       2   Volume ratio  1.67   Variation (σ/μ) 1.31e-01   Residual 1.24e-01
+#       3   Volume ratio  1.41   Variation (σ/μ) 7.57e-02   Residual 6.58e-02
+#       4   Volume ratio  1.29   Variation (σ/μ) 4.77e-02   Residual 3.49e-02
+#       5   Volume ratio  1.20   Variation (σ/μ) 3.37e-02   Residual 1.73e-02
+#       6   Volume ratio  1.17   Variation (σ/μ) 2.81e-02   Residual 7.75e-03
+#       7   Volume ratio  1.15   Variation (σ/μ) 2.64e-02   Residual 3.16e-03
+#       8   Volume ratio  1.15   Variation (σ/μ) 2.59e-02   Residual 1.16e-03
+#       9   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 3.88e-04
+#      10   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 1.16e-04
+#      11   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 1.56e-05
+#      12   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 7.57e-06
+#      13   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 3.58e-06
+#      14   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 1.51e-06
+#      15   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 5.71e-07
+#      16   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 1.94e-07
+#      17   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 5.86e-08
+#    Solver converged in 17 iterations.
 #
 # Plotting the resulting mesh:
 

--- a/movement/laplacian_smoothing.py
+++ b/movement/laplacian_smoothing.py
@@ -100,3 +100,9 @@ class LaplacianSmoother(PrimeMover):
         self.x.dat.data_with_halos[:] += self.displacement
         self.mesh.coordinates.assign(self.x)
         self.volume.interpolate(ufl.CellVolume(self.mesh))
+        PETSc.Sys.Print(
+            f"{time:.2f} s"
+            f"   Min/Max {self.volume_ratio:10.4e}"
+            f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+            f"   Displacement {np.linalg.norm(self.displacement):.2f} m"
+        )

--- a/movement/laplacian_smoothing.py
+++ b/movement/laplacian_smoothing.py
@@ -102,7 +102,7 @@ class LaplacianSmoother(PrimeMover):
         self.volume.interpolate(ufl.CellVolume(self.mesh))
         PETSc.Sys.Print(
             f"{time:.2f} s"
-            f"   Min/Max {self.volume_ratio:10.4e}"
-            f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+            f"   Volume ratio {self.volume_ratio:5.2f}"
+            f"   Variation (σ/μ) {self.coefficient_of_variation:8.2e}"
             f"   Displacement {np.linalg.norm(self.displacement):.2f} m"
         )

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -158,7 +158,7 @@ class MongeAmpereMover_Base(PrimeMover, metaclass=abc.ABCMeta):
         :rtype: :class:`float`
         """
         volume_array = self.volume.vector().gather()
-        mean = volume_array.sum() / volume_array.max()
+        mean = volume_array.sum() / volume_array.size
         return np.sqrt(np.sum((volume_array - mean) ** 2) / volume_array.size) / mean
 
     @property

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -360,7 +360,8 @@ class MongeAmpereMover_Relaxation(MongeAmpereMover_Base):
 
             # Update monitor function
             self.monitor.interpolate(self.monitor_function(self.mesh))
-            self.volume.interpolate(self.L_P0 / self.original_volume)
+            firedrake.assemble(self.L_P0, tensor=self.volume)
+            self.volume.interpolate(self.volume / self.original_volume)
             self.mesh.coordinates.assign(self.xi)
 
             # Evaluate normalisation coefficient
@@ -520,7 +521,8 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
             cursol = snes.getSolution()
             update_monitor(cursol)
             self._update_coordinates()
-            self.volume.interpolate(self.L_P0 / self.original_volume)
+            firedrake.assemble(self.L_P0, tensor=self.volume)
+            self.volume.interpolate(self.volume / self.original_volume)
             self.mesh.coordinates.assign(self.xi)
             PETSc.Sys.Print(
                 f"{i:4d}"

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -139,25 +139,6 @@ class MongeAmpereMover_Base(PrimeMover, metaclass=abc.ABCMeta):
             raise ValueError("Need to initialise both phi *and* sigma.")
 
     @property
-    def volume_ratio(self):
-        """
-        :return: the ratio of the smallest and largest element volumes.
-        :rtype: :class:`float`
-        """
-        volume_array = self.volume.vector().gather()
-        return volume_array.min() / volume_array.max()
-
-    @property
-    def coefficient_of_variation(self):
-        """
-        :return: the coefficient of variation (σ/μ) of element volumes.
-        :rtype: :class:`float`
-        """
-        volume_array = self.volume.vector().gather()
-        mean = volume_array.sum() / volume_array.size
-        return np.sqrt(np.sum((volume_array - mean) ** 2) / volume_array.size) / mean
-
-    @property
     def relative_l2_residual(self):
         """
         :return: the relative :math:`L^2` norm residual.

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -373,8 +373,8 @@ class MongeAmpereMover_Relaxation(MongeAmpereMover_Base):
             PETSc.Sys.Print(
                 f"{i:4d}"
                 f"   Min/Max {self.volume_ratio:10.4e}"
-                f"   Residual {residual:10.4e}"
                 f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+                f"   Residual {residual:10.4e}"
             )
             if residual < self.rtol:
                 self._convergence_message(i + 1)
@@ -525,8 +525,8 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
             PETSc.Sys.Print(
                 f"{i:4d}"
                 f"   Min/Max {self.volume_ratio:10.4e}"
-                f"   Residual {self.relative_l2_residual:10.4e}"
                 f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+                f"   Residual {self.relative_l2_residual:10.4e}"
             )
 
         self.snes = self._equidistributor.snes

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -373,9 +373,9 @@ class MongeAmpereMover_Relaxation(MongeAmpereMover_Base):
                 initial_norm = residual
             PETSc.Sys.Print(
                 f"{i:4d}"
-                f"   Min/Max {self.volume_ratio:10.4e}"
-                f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
-                f"   Residual {residual:10.4e}"
+                f"   Volume ratio {self.volume_ratio:5.2f}"
+                f"   Variation (σ/μ) {self.coefficient_of_variation:8.2e}"
+                f"   Residual {residual:8.2e}"
             )
             if residual < self.rtol:
                 self._convergence_message(i + 1)
@@ -526,9 +526,9 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
             self.mesh.coordinates.assign(self.xi)
             PETSc.Sys.Print(
                 f"{i:4d}"
-                f"   Min/Max {self.volume_ratio:10.4e}"
-                f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
-                f"   Residual {self.relative_l2_residual:10.4e}"
+                f"   Volume ratio {self.volume_ratio:5.2f}"
+                f"   Variation (σ/μ) {self.coefficient_of_variation:8.2e}"
+                f"   Residual {self.relative_l2_residual:8.2e}"
             )
 
         self.snes = self._equidistributor.snes

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -175,6 +175,25 @@ class PrimeMover:
         """
         return self.mesh.coordinates.dat.data_with_halos[self.get_offset(index)]
 
+    @property
+    def volume_ratio(self):
+        """
+        :return: the ratio of the smallest and largest element volumes.
+        :rtype: :class:`float`
+        """
+        volume_array = self.volume.vector().gather()
+        return volume_array.min() / volume_array.max()
+
+    @property
+    def coefficient_of_variation(self):
+        """
+        :return: the coefficient of variation (σ/μ) of element volumes.
+        :rtype: :class:`float`
+        """
+        volume_array = self.volume.vector().gather()
+        mean = volume_array.sum() / volume_array.size
+        return np.sqrt(np.sum((volume_array - mean) ** 2) / volume_array.size) / mean
+
     def move(self):
         """
         Move the mesh according to the method of choice.

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -178,11 +178,11 @@ class PrimeMover:
     @property
     def volume_ratio(self):
         """
-        :return: the ratio of the smallest and largest element volumes.
+        :return: the ratio of the largest and smallest element volumes.
         :rtype: :class:`float`
         """
         volume_array = self.volume.vector().gather()
-        return volume_array.min() / volume_array.max()
+        return volume_array.max() / volume_array.min()
 
     @property
     def coefficient_of_variation(self):

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -273,8 +273,8 @@ class SpringMover_Lineal(SpringMover_Base):
         self.volume.interpolate(ufl.CellVolume(self.mesh))
         PETSc.Sys.Print(
             f"{time:.2f}"
-            f"   Min/Max {self.volume_ratio:10.4e}"
-            f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+            f"   Volume ratio {self.volume_ratio:5.2f}"
+            f"   Variation (σ/μ) {self.coefficient_of_variation:8.2e}"
             f"   Displacement {np.linalg.norm(self.displacement):.2f} m"
         )
 

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -271,6 +271,12 @@ class SpringMover_Lineal(SpringMover_Base):
         self.mesh.coordinates.dat.data_with_halos[:] += self.displacement.reshape(shape)
         self._update_plex_coordinates()
         self.volume.interpolate(ufl.CellVolume(self.mesh))
+        PETSc.Sys.Print(
+            f"{time:.2f}"
+            f"   Min/Max {self.volume_ratio:10.4e}"
+            f"   Variation (σ/μ) {self.coefficient_of_variation:10.4e}"
+            f"   Displacement {np.linalg.norm(self.displacement):.2f} m"
+        )
 
 
 class SpringMover_Torsional(SpringMover_Lineal):


### PR DESCRIPTION
Closes #102.

Separates out diagnostics, pulls them up to the `PrimeMover` base class, and makes use of them in all movers. This improves the consistency of what's printed to screen by the different movers.