### PR TITLE
Refactor `PrimeMover`

### DIFF
--- a/movement/mover.py
+++ b/movement/mover.py
@@ -51,11 +51,19 @@ class PrimeMover(abc.ABC):
         self.raise_convergence_errors = raise_convergence_errors
         self.dim = self.mesh.topological_dimension()
         self.gdim = self.mesh.geometric_dimension()
+
+        # DMPlex setup
         self.plex = self.mesh.topology_dm
         self.vertex_indices = self.plex.getDepthStratum(0)
         self.edge_indices = self.plex.getDepthStratum(1)
+        entity_dofs = np.zeros(self.dim + 1, dtype=np.int32)
+        entity_dofs[0] = self.gdim
+        self._coordinate_section = create_section(self.mesh, entity_dofs)[0]
+        dm_coords = self.plex.getCoordinateDM()
+        dm_coords.setDefaultSection(self._coordinate_section)
+        self._local_coordinates_vec = dm_coords.createLocalVec()
+        self._update_plex_coordinates()
 
-        # Measures
         self.dx = firedrake.dx(domain=self.mesh, degree=quadrature_degree)
         self.ds = firedrake.ds(domain=self.mesh, degree=quadrature_degree)
         self.dS = firedrake.dS(domain=self.mesh, degree=quadrature_degree)
@@ -71,12 +79,10 @@ class PrimeMover(abc.ABC):
                 self.mesh, raise_error=raise_convergence_errors
             )
 
-    @abc.abstractmethod
     def _create_function_spaces(self):
         self.coord_space = self.mesh.coordinates.function_space()
         self.P0 = firedrake.FunctionSpace(self.mesh, "DG", 0)
 
-    @abc.abstractmethod
     def _create_functions(self):
         self.x = firedrake.Function(self.mesh.coordinates, name="Physical coordinates")
         self.xi = firedrake.Function(
@@ -146,53 +152,38 @@ class PrimeMover(abc.ABC):
             msg += f" after {iterations} iteration{plural(iterations)}"
         self._exception(f"{msg}.", exception=exception)
 
-    def _get_coordinate_section(self):
-        entity_dofs = np.zeros(self.dim + 1, dtype=np.int32)
-        entity_dofs[0] = self.gdim
-        self._coordinate_section = create_section(self.mesh, entity_dofs)[0]
-        dm_coords = self.plex.getCoordinateDM()
-        dm_coords.setDefaultSection(self._coordinate_section)
-        self._coords_local_vec = dm_coords.createLocalVec()
-        self._update_plex_coordinates()
-
     def _update_plex_coordinates(self):
-        if not hasattr(self, "_coords_local_vec"):
-            self._get_coordinate_section()
-        self._coords_local_vec.array[:] = np.reshape(
+        """
+        Update the underlying DMPlex coordinates with the coordinates of the Firedrake
+        mesh.
+        """
+        self._local_coordinates_vec.array[:] = np.reshape(
             self.mesh.coordinates.dat.data_with_halos,
-            self._coords_local_vec.array.shape,
+            self._local_coordinates_vec.array.shape,
         )
-        self.plex.setCoordinatesLocal(self._coords_local_vec)
+        self.plex.setCoordinatesLocal(self._local_coordinates_vec)
 
-    def _get_edge_vector_section(self):
-        entity_dofs = np.zeros(self.dim + 1, dtype=np.int32)
-        entity_dofs[1] = 1
-        self._edge_vector_section = create_section(self.mesh, entity_dofs)[0]
+    def _coordinate_offset(self, index):
+        """
+        Map the index of a DMPlex coordinate to the coordinate index in Firedrake.
 
-    def coordinate_offset(self, index):
+        :arg index: DMPlex coordinate index
+        :type index: :class:`int`
         """
-        Get the DMPlex coordinate section offset
-        for a given `index`.
-        """
-        if not hasattr(self, "_coordinate_section"):
-            self._get_coordinate_section()
         return self._coordinate_section.getOffset(index) // self.dim
 
-    def edge_vector_offset(self, index):
+    def _edge_offset(self, index):
         """
-        Get the DMPlex edge vector section offset
-        for a given `index`.
+        Map the index of a DMPlex edge to the edge index in Firedrake.
+
+        :arg index: DMPlex edge index
+        :type index: :class:`int`
         """
         if not hasattr(self, "_edge_vector_section"):
-            self._get_edge_vector_section()
+            entity_dofs = np.zeros(self.dim + 1, dtype=np.int32)
+            entity_dofs[1] = 1
+            self._edge_vector_section = create_section(self.mesh, entity_dofs)[0]
         return self._edge_vector_section.getOffset(index)
-
-    def coordinate(self, index):
-        """
-        Get the mesh coordinate associated with
-        a given `index`.
-        """
-        return self.mesh.coordinates.dat.data_with_halos[self.get_offset(index)]
 
     @property
     def volume_ratio(self):

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -13,7 +13,7 @@ from movement.tangling import MeshTanglingChecker
 __all__ = ["PrimeMover"]
 
 
-class PrimeMover:
+class PrimeMover(abc.ABC):
     """
     Base class for all mesh movers.
     """
@@ -212,11 +212,12 @@ class PrimeMover:
         mean = volume_array.sum() / volume_array.size
         return np.sqrt(np.sum((volume_array - mean) ** 2) / volume_array.size) / mean
 
+    @abc.abstractmethod
     def move(self):
         """
         Move the mesh according to the method of choice.
         """
-        raise NotImplementedError("Implement `move` in the derived class.")
+        pass
 
 
 def plural(iterations):

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -213,4 +213,8 @@ class PrimeMover(abc.ABC):
 
 
 def plural(iterations):
+    """
+    :return: 's' if `iterations` should be referred to in the plural sense
+    :rtype: :class:`str`
+    """
     return "s" if iterations != 1 else ""

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -24,7 +24,7 @@ class PrimeMover(abc.ABC):
         monitor_function=None,
         raise_convergence_errors=True,
         tangling_check=None,
-        **kwargs,
+        quadrature_degree=None,
     ):
         r"""
         :arg mesh: the physical mesh
@@ -38,6 +38,8 @@ class PrimeMover(abc.ABC):
         :kwarg tangling_check: check whether the mesh has tangled elements (by default
             on in the 2D case and off otherwise)
         :type tangling_check: :class:`bool`
+        :kwarg quadrature_degree: quadrature degree to be passed to Firedrakes measures
+        :type quadrature_degree: :class:`int`
         """
         self.mesh = firedrake.Mesh(mesh.coordinates.copy(deepcopy=True))
         self.monitor_function = monitor_function
@@ -54,10 +56,9 @@ class PrimeMover(abc.ABC):
         self.edge_indices = self.plex.getDepthStratum(1)
 
         # Measures
-        degree = kwargs.get("quadrature_degree")
-        self.dx = firedrake.dx(domain=self.mesh, degree=degree)
-        self.ds = firedrake.ds(domain=self.mesh, degree=degree)
-        self.dS = firedrake.dS(domain=self.mesh, degree=degree)
+        self.dx = firedrake.dx(domain=self.mesh, degree=quadrature_degree)
+        self.ds = firedrake.ds(domain=self.mesh, degree=quadrature_degree)
+        self.dS = firedrake.dS(domain=self.mesh, degree=quadrature_degree)
 
         self._create_function_spaces()
         self._create_functions()

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -209,7 +209,7 @@ class PrimeMover(abc.ABC):
         """
         Move the mesh according to the method of choice.
         """
-        pass
+        pass  # pragma: no cover
 
 
 def plural(iterations):

--- a/movement/mover.py
+++ b/movement/mover.py
@@ -218,17 +218,6 @@ class PrimeMover:
         """
         raise NotImplementedError("Implement `move` in the derived class.")
 
-    def adapt(self):
-        """
-        Alias of `move`.
-        """
-        warn(
-            "`adapt` is deprecated (use `move` instead)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.move()
-
 
 def plural(iterations):
     return "s" if iterations != 1 else ""

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -149,8 +149,8 @@ class SpringMover_Base(PrimeMover):
 
         K = np.zeros((2 * Nv, 2 * Nv))
         for e in range(*self.edge_indices):
-            off = self.edge_vector_offset(e)
-            i, j = (self.coordinate_offset(v) for v in self.plex.getCone(e))
+            off = self._edge_offset(e)
+            i, j = (self._coordinate_offset(v) for v in self.plex.getCone(e))
             l = edge_lengths.dat.data_with_halos[off]
             angle = angles.dat.data_with_halos[off]
             c = np.cos(angle)
@@ -224,7 +224,7 @@ class SpringMover_Base(PrimeMover):
             for e in range(*self.edge_indices):
                 if bnd.point2facetnumber[e] not in subsets:
                     continue
-                i, j = (self.coordinate_offset(v) for v in self.plex.getCone(e))
+                i, j = (self._coordinate_offset(v) for v in self.plex.getCone(e))
                 self._forcing[i, :] = boundary_data[i, :]
                 self._forcing[j, :] = boundary_data[j, :]
                 for k in (2 * i, 2 * i + 1, 2 * j, 2 * j + 1):

--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -197,12 +197,12 @@ class TestMongeAmpere(unittest.TestCase):
 
     def test_coordinate_update(self):
         mesh = self.mesh(2, n=2)
-        dg_coords = Function(VectorFunctionSpace(mesh, "DG", 1))
-        dg_coords.project(mesh.coordinates)
-        mover = MongeAmpereMover(Mesh(dg_coords), const_monitor)
-        mover._grad_phi.assign(2.0)
+        x, y = SpatialCoordinate(mesh)
+        coords = Function(VectorFunctionSpace(mesh, "CG", 1))
+        coords.interpolate(as_vector([x + 1, y]))
+        mover = MongeAmpereMover(Mesh(coords), const_monitor)
+        mover._grad_phi.interpolate(as_vector([1, 0]))
         mover._update_coordinates()
-        self.assertNotEqual(mover.grad_phi.dof_dset.size, mover._grad_phi.dof_dset.size)
         self.assertAlmostEqual(errornorm(mover.grad_phi, mover._grad_phi), 0)
-        mover.xi += 2
+        mover.xi.dat.data[:, 0] += 1
         self.assertAlmostEqual(errornorm(mover.x, mover.xi), 0)

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -11,26 +11,27 @@ class TestTangling(unittest.TestCase):
     """
 
     def test_tangling_checker_error1(self):
-        mesh = UnitSquareMesh(3, 3)
-        checker = MeshTanglingChecker(mesh, raise_error=True)
-        mesh.coordinates.dat.data[3] += 0.2
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=True)
+        checker.mesh.coordinates.dat.data[3] += 0.2
         with self.assertRaises(ValueError) as cm:
             checker.check()
-        msg = "Mesh has 1 tangled element."
-        self.assertEqual(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), "Mesh has 1 tangled element.")
 
     def test_tangling_checker_error2(self):
-        mesh = UnitSquareMesh(3, 3)
-        checker = MeshTanglingChecker(mesh, raise_error=True)
-        mesh.coordinates.dat.data[3] += 0.5
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=True)
+        checker.mesh.coordinates.dat.data[3] += 0.5
         with self.assertRaises(ValueError) as cm:
             checker.check()
-        msg = "Mesh has 3 tangled elements."
+        self.assertEqual(str(cm.exception), "Mesh has 3 tangled elements.")
+
+    def test_tangling_checker_dim_error(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            MeshTanglingChecker(UnitIntervalMesh(1))
+        msg = "Tangling check only currently supported in 2D."
         self.assertEqual(str(cm.exception), msg)
 
     def test_tangling_checker_warning1(self):
-        mesh = UnitSquareMesh(3, 3)
-        checker = MeshTanglingChecker(mesh, raise_error=False)
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
         self.assertEqual(checker.check(), 0)
-        mesh.coordinates.dat.data[3] += 0.2
+        checker.mesh.coordinates.dat.data[3] += 0.2
         self.assertEqual(checker.check(), 1)


### PR DESCRIPTION
Partially addresses #19.
Partially addresses #78.
Closes #44.

Rearranges the `PrimeMover` base class and gets 100% code coverage for it. Minor tweaks to tests, including for `MeshTanglingChecker`.