### PR TITLE
Drop outdated FIXME

### DIFF
--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -93,8 +93,6 @@ class TestMongeAmpere(unittest.TestCase):
 
         self.assertLessEqual(num_it_continue, num_it_naive)
         self.assertLessEqual(num_it_init + num_it_continue, num_it_naive)
-        # FIXME: Looks like the mesh is tangled or close to tangling
-        #        for the relaxation method, which is concerning.
 
     @parameterized.expand(
         [(2, "relaxation"), (2, "quasi_newton"), (3, "relaxation"), (3, "quasi_newton")]


### PR DESCRIPTION
Closes #4.

Digging into this on branch https://github.com/mesh-adaptation/movement/compare/4_tangling_debug the issue no longer appears to be of concern. For the 2D case we are already using tangling checking by default and nothing was being picked up. Investigating the moved meshes, max/min volume ratios, and minimum angles, nothing appears to be of concern:

![mesh_relaxation_2d_before](https://github.com/user-attachments/assets/808e7836-2114-4745-a550-7cf13ad581b0)

![mesh_relaxation_2d_after](https://github.com/user-attachments/assets/5f9720ab-7e1c-42c1-94af-951df916f1e0)