### PR TITLE
Fix for failing tests since new Firedrake update

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test_suite:
-    uses: mesh-adaptation/mesh-adaptation-docs/.github/workflows/reusable_test_suite.yml@main
+    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml@main
     with:
       install-command: 'python -m pip uninstall -y movement && python -m pip install -e .'
       test-command: |

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -3,7 +3,6 @@ Mesh movement based on solutions of equations of Monge-Ampère type.
 """
 
 import abc
-from collections.abc import Iterable
 from warnings import warn
 
 import firedrake
@@ -151,8 +150,6 @@ class MongeAmpereMover_Base(PrimeMover, metaclass=abc.ABCMeta):
         # Handle boundary segments where zero Dirichlet conditions are applied
         if self.fixed_boundary_segments == "on_boundary":
             self.fixed_boundary_segments = self._all_boundary_segments
-        elif not isinstance(self.fixed_boundary_segments, Iterable):
-            self.fixed_boundary_segments = [self.fixed_boundary_segments]
         if len(self._all_boundary_segments) == 0:
             warn(
                 "Provided mesh has no boundary segments with Physical ID tags. If the "

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -207,7 +207,6 @@ class SpringMover_Base(PrimeMover):
             tags = boundary_condition.sub_domain
             if tags == ("on_boundary",):
                 tags = bnd.unique_markers
-            tags = [tags] if not isinstance(tags, Iterable) else tags
             if not set(tags).issubset(set(bnd.unique_markers)):
                 raise ValueError(f"{tags} contains invalid boundary tags.")
             subsets = np.array([bnd.subset(tag).indices for tag in tags]).flatten()

--- a/movement/spring.py
+++ b/movement/spring.py
@@ -205,7 +205,7 @@ class SpringMover_Base(PrimeMover):
             # Determine boundary subsets for the associated tags
             bnd = self.mesh.exterior_facets
             tags = boundary_condition.sub_domain
-            if tags == "on_boundary":
+            if tags == ("on_boundary",):
                 tags = bnd.unique_markers
             tags = [tags] if not isinstance(tags, Iterable) else tags
             if not set(tags).issubset(set(bnd.unique_markers)):

--- a/test/test_spring.py
+++ b/test/test_spring.py
@@ -41,7 +41,7 @@ class TestExceptions(unittest.TestCase):
         bc = DirichletBC(mover.coord_space, 0, 4)
         with self.assertRaises(ValueError) as cm:
             mover.assemble_stiffness_matrix(bc)
-        msg = "[4] contains invalid boundary tags."
+        msg = "(4,) contains invalid boundary tags."
         self.assertEqual(str(cm.exception), msg)
 
     def test_convergence_error(self):


### PR DESCRIPTION
Closes #138

Firedrake now returns `boundary_condition.sub_domain` as a tuple ( https://github.com/firedrakeproject/firedrake/pull/3905/files#diff-5dfb97c8200daf2aa6c38c106bcf5c6d85fde86e14a56f851cf6d03cdf91245b )