### PR TITLE
Implement `MeshTanglingChecker` in 1D and 3D

### DIFF
--- a/movement/mover.py
+++ b/movement/mover.py
@@ -23,7 +23,7 @@ class PrimeMover(abc.ABC):
         mesh,
         monitor_function=None,
         raise_convergence_errors=True,
-        tangling_check=None,
+        tangling_check=True,
         quadrature_degree=None,
     ):
         r"""
@@ -35,8 +35,8 @@ class PrimeMover(abc.ABC):
             then :class:`~.ConvergenceError`\s are raised, else warnings are raised and
             the program is allowed to continue
         :type raise_convergence_errors: :class:`bool`
-        :kwarg tangling_check: check whether the mesh has tangled elements (by default
-            on in the 2D case and off otherwise)
+        :kwarg tangling_check: check whether the mesh has tangled elements (on by
+            default)
         :type tangling_check: :class:`bool`
         :kwarg quadrature_degree: quadrature degree to be passed to Firedrakes measures
         :type quadrature_degree: :class:`int`
@@ -78,8 +78,6 @@ class PrimeMover(abc.ABC):
         self._all_boundary_segments = self.mesh.exterior_facets.unique_markers
 
         # Utilities
-        if tangling_check is None:
-            tangling_check = self.dim == 2
         if tangling_check:
             self.tangling_checker = MeshTanglingChecker(
                 self.mesh, raise_error=raise_convergence_errors

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -43,7 +43,7 @@ class MeshTanglingChecker:
         was created.
         """
         jdr = self.jacobian_determinant_ratio.dat.data_with_halos
-        num_tangled = len(jdr[jdr < 0])
+        num_tangled = len(jdr[jdr <= 0])
         if num_tangled > 0:
             plural = "s" if num_tangled > 1 else ""
             msg = f"Mesh has {num_tangled} tangled element{plural}."

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -9,13 +9,13 @@ __all__ = ["MeshTanglingChecker"]
 
 class MeshTanglingChecker:
     """
-    Class for tracking whether a mesh has tangled, i.e. whether any of its elements
+    A class for tracking whether a mesh has tangled, i.e. whether any of its elements
     have become inverted.
     """
 
     def __init__(self, mesh, raise_error=True):
         """
-        :arg mesh: the mesh to track if tangled
+        :kwarg mesh: the mesh to track if tangled
         :type mesh: :class:`firedrake.mesh.MeshGeometry`
         :arg raise_error: if ``True``, an error is raised if any element is tangled,
             otherwise a warning is raised
@@ -24,16 +24,14 @@ class MeshTanglingChecker:
         self.mesh = mesh
         self.raise_error = raise_error
         P0 = firedrake.FunctionSpace(mesh, "DG", 0)
-        self._sj = firedrake.Function(P0)
+        self._jacobian_sign = firedrake.Function(P0)
         detJ = ufl.JacobianDeterminant(mesh)
         s = firedrake.assemble(interpolate(ufl.sign(detJ), P0))
-        self._sj_expr = ufl.sign(detJ) / s
+        self._jacobian_sign_expr = ufl.sign(detJ) / s
 
     @property
     def scaled_jacobian(self):
-        assert self._sj_expr is not None
-        self._sj.interpolate(self._sj_expr)
-        return self._sj
+        return self._jacobian_sign.interpolate(self._jacobian_sign_expr)
 
     def check(self):
         """

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -84,25 +84,9 @@ class MeshTanglingChecker_2D(MeshTanglingChecker_Base):
         :type raise_error: :class:`bool`
         """
         super().__init__(mesh, raise_error)
-
-        # Store initial signs of Jacobian determinant
         detJ = ufl.JacobianDeterminant(mesh)
         s = firedrake.assemble(interpolate(ufl.sign(detJ), self.P0))
-
-        # Get scaled Jacobian expression
-        P0_ten = firedrake.TensorFunctionSpace(mesh, "DG", 0)
-        J = firedrake.assemble(interpolate(ufl.Jacobian(mesh), P0_ten))
-        edge1 = ufl.as_vector([J[0, 0], J[1, 0]])
-        edge2 = ufl.as_vector([J[0, 1], J[1, 1]])
-        edge3 = edge1 - edge2
-        norm1 = ufl.sqrt(ufl.dot(edge1, edge1))
-        norm2 = ufl.sqrt(ufl.dot(edge2, edge2))
-        norm3 = ufl.sqrt(ufl.dot(edge3, edge3))
-        prod1 = ufl.max_value(norm1 * norm2, norm1 * norm3)
-        prod2 = ufl.max_value(norm2 * norm3, norm2 * norm1)
-        prod3 = ufl.max_value(norm3 * norm1, norm3 * norm2)
-        maxval = ufl.max_value(ufl.max_value(prod1, prod2), prod3)
-        self._sj_expr = detJ / maxval * s
+        self._sj_expr = ufl.sign(detJ) / s
 
 
 def MeshTanglingChecker(mesh, **kwargs):

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -25,17 +25,18 @@ class MeshTanglingChecker:
         self.raise_error = raise_error
         P0 = firedrake.FunctionSpace(mesh, "DG", 0)
         detJ = ufl.JacobianDeterminant(mesh)
-        self._detJ_ratio_expr = detJ / firedrake.assemble(interpolate(detJ, P0))
-        self._detJ_ratio = firedrake.Function(P0).interpolate(self._detJ_ratio_expr)
+        self._detJ_ratio_expr = detJ / firedrake.Function(P0).interpolate(detJ)
+        self._detJ_ratio = firedrake.Function(P0)
 
     @property
     def jacobian_determinant_ratio(self):
         """
-        Compute the ratio of the determinant of the Jacobian for the current mesh with
+        Compute the ratio of the determinant of the Jacobian of the current mesh to
         the determinant of the Jacobian of the original mesh.
         """
         return self._detJ_ratio.interpolate(self._detJ_ratio_expr)
 
+    @PETSc.Log.EventDecorator()
     def check(self):
         """
         Check whether any element orientations have changed since the tangling checker

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -109,6 +109,10 @@ def MeshTanglingChecker(mesh, **kwargs):
     """
     Factory function for creating mesh tangling checker classes.
 
+    Note that the implementation is based on element orientations, so a reflection in
+    the :math:`x` coordinate (for example) will report mesh tangling, even though the
+    mesh doesn't 'look' tangled.
+
     :arg mesh: the mesh to track if tangled
     :type mesh: :class:`firedrake.mesh.MeshGeometry`
     :kwarg raise_error: if ``True``, an error is raised if any element is tangled,

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -24,14 +24,14 @@ class MeshTanglingChecker:
         self.mesh = mesh
         self.raise_error = raise_error
         P0 = firedrake.FunctionSpace(mesh, "DG", 0)
-        self._jacobian_sign = firedrake.Function(P0)
+        self._detJ = firedrake.Function(P0)
         detJ = ufl.JacobianDeterminant(mesh)
-        s = firedrake.assemble(interpolate(ufl.sign(detJ), P0))
-        self._jacobian_sign_expr = ufl.sign(detJ) / s
+        s = firedrake.assemble(interpolate(detJ, P0))
+        self._detJ_expr = detJ / s
 
     @property
     def scaled_jacobian(self):
-        return self._jacobian_sign.interpolate(self._jacobian_sign_expr)
+        return self._detJ.interpolate(self._detJ_expr)
 
     def check(self):
         """

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -1,3 +1,4 @@
+import abc
 import warnings
 
 import firedrake
@@ -7,48 +8,30 @@ from firedrake.__future__ import interpolate
 __all__ = ["MeshTanglingChecker"]
 
 
-class MeshTanglingChecker:
+class MeshTanglingChecker_Base(abc.ABC):
     """
-    A class for tracking whether a mesh has tangled, i.e. whether any of its elements
+    Base class for tracking whether a mesh has tangled, i.e. whether any of its elements
     have become inverted.
     """
 
-    def __init__(self, mesh, raise_error=True):
+    @abc.abstractmethod
+    def __init__(self, mesh, raise_error):
         """
         :arg mesh: the mesh to track if tangled
         :type mesh: :class:`firedrake.mesh.MeshGeometry`
-        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
+        :arg raise_error: if ``True``, an error is raised if any element is tangled,
             otherwise a warning is raised
         :type raise_error: :class:`bool`
         """
-        if mesh.topological_dimension() != 2:
-            raise NotImplementedError("Tangling check only currently supported in 2D.")
         self.mesh = mesh
         self.raise_error = raise_error
-
-        # Store initial signs of Jacobian determinant
-        P0 = firedrake.FunctionSpace(mesh, "DG", 0)
-        detJ = ufl.JacobianDeterminant(mesh)
-        s = firedrake.assemble(interpolate(ufl.sign(detJ), P0))
-
-        # Get scaled Jacobian expression
-        P0_ten = firedrake.TensorFunctionSpace(mesh, "DG", 0)
-        J = firedrake.assemble(interpolate(ufl.Jacobian(mesh), P0_ten))
-        edge1 = ufl.as_vector([J[0, 0], J[1, 0]])
-        edge2 = ufl.as_vector([J[0, 1], J[1, 1]])
-        edge3 = edge1 - edge2
-        norm1 = ufl.sqrt(ufl.dot(edge1, edge1))
-        norm2 = ufl.sqrt(ufl.dot(edge2, edge2))
-        norm3 = ufl.sqrt(ufl.dot(edge3, edge3))
-        prod1 = ufl.max_value(norm1 * norm2, norm1 * norm3)
-        prod2 = ufl.max_value(norm2 * norm3, norm2 * norm1)
-        prod3 = ufl.max_value(norm3 * norm1, norm3 * norm2)
-        maxval = ufl.max_value(ufl.max_value(prod1, prod2), prod3)
-        self._sj_expr = detJ / maxval * s
-        self._sj = firedrake.Function(P0)
+        self.P0 = firedrake.FunctionSpace(mesh, "DG", 0)
+        self._sj = firedrake.Function(self.P0)
+        self._sj_expr = None
 
     @property
     def scaled_jacobian(self):
+        assert self._sj_expr is not None
         self._sj.interpolate(self._sj_expr)
         return self._sj
 
@@ -66,3 +49,58 @@ class MeshTanglingChecker:
                 raise ValueError(msg)
             warnings.warn(msg, stacklevel=1)
         return num_tangled
+
+
+class MeshTanglingChecker_2D(MeshTanglingChecker_Base):
+    """
+    Implementation of mesh tangling check in 2D.
+    """
+
+    def __init__(self, mesh, raise_error=True):
+        """
+        :arg mesh: the mesh to track if tangled
+        :type mesh: :class:`firedrake.mesh.MeshGeometry`
+        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
+            otherwise a warning is raised
+        :type raise_error: :class:`bool`
+        """
+        super().__init__(mesh, raise_error)
+
+        # Store initial signs of Jacobian determinant
+        detJ = ufl.JacobianDeterminant(mesh)
+        s = firedrake.assemble(interpolate(ufl.sign(detJ), self.P0))
+
+        # Get scaled Jacobian expression
+        P0_ten = firedrake.TensorFunctionSpace(mesh, "DG", 0)
+        J = firedrake.assemble(interpolate(ufl.Jacobian(mesh), P0_ten))
+        edge1 = ufl.as_vector([J[0, 0], J[1, 0]])
+        edge2 = ufl.as_vector([J[0, 1], J[1, 1]])
+        edge3 = edge1 - edge2
+        norm1 = ufl.sqrt(ufl.dot(edge1, edge1))
+        norm2 = ufl.sqrt(ufl.dot(edge2, edge2))
+        norm3 = ufl.sqrt(ufl.dot(edge3, edge3))
+        prod1 = ufl.max_value(norm1 * norm2, norm1 * norm3)
+        prod2 = ufl.max_value(norm2 * norm3, norm2 * norm1)
+        prod3 = ufl.max_value(norm3 * norm1, norm3 * norm2)
+        maxval = ufl.max_value(ufl.max_value(prod1, prod2), prod3)
+        self._sj_expr = detJ / maxval * s
+
+
+def MeshTanglingChecker(mesh, **kwargs):
+    """
+    Factory function for creating mesh tangling checker classes.
+
+    :arg mesh: the mesh to track if tangled
+    :type mesh: :class:`firedrake.mesh.MeshGeometry`
+    :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
+        otherwise a warning is raised
+    :type raise_error: :class:`bool`
+    """
+    dim = mesh.topological_dimension()
+    try:
+        implementations = {
+            2: MeshTanglingChecker_2D,
+        }
+        return implementations[dim](mesh, **kwargs)
+    except KeyError as ke:
+        raise ValueError(f"Mesh dimension {dim} not supported.") from ke

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -51,6 +51,25 @@ class MeshTanglingChecker_Base(abc.ABC):
         return num_tangled
 
 
+class MeshTanglingChecker_1D(MeshTanglingChecker_Base):
+    """
+    Implementation of mesh tangling check in 1D.
+    """
+
+    def __init__(self, mesh, raise_error=True):
+        """
+        :arg mesh: the mesh to track if tangled
+        :type mesh: :class:`firedrake.mesh.MeshGeometry`
+        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
+            otherwise a warning is raised
+        :type raise_error: :class:`bool`
+        """
+        super().__init__(mesh, raise_error)
+        detJ = ufl.JacobianDeterminant(mesh)
+        s = firedrake.assemble(interpolate(ufl.sign(detJ), self.P0))
+        self._sj_expr = ufl.sign(detJ) / s
+
+
 class MeshTanglingChecker_2D(MeshTanglingChecker_Base):
     """
     Implementation of mesh tangling check in 2D.
@@ -99,6 +118,7 @@ def MeshTanglingChecker(mesh, **kwargs):
     dim = mesh.topological_dimension()
     try:
         implementations = {
+            1: MeshTanglingChecker_1D,
             2: MeshTanglingChecker_2D,
         }
         return implementations[dim](mesh, **kwargs)

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -2,7 +2,7 @@ import warnings
 
 import firedrake
 import ufl
-from firedrake.__future__ import interpolate
+from firedrake.petsc import PETSc
 
 __all__ = ["MeshTanglingChecker"]
 
@@ -15,9 +15,9 @@ class MeshTanglingChecker:
 
     def __init__(self, mesh, raise_error=True):
         """
-        :kwarg mesh: the mesh to track if tangled
+        :arg mesh: the mesh to track if tangled
         :type mesh: :class:`firedrake.mesh.MeshGeometry`
-        :arg raise_error: if ``True``, an error is raised if any element is tangled,
+        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
             otherwise a warning is raised
         :type raise_error: :class:`bool`
         """

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -1,4 +1,3 @@
-import abc
 import warnings
 
 import firedrake
@@ -8,14 +7,13 @@ from firedrake.__future__ import interpolate
 __all__ = ["MeshTanglingChecker"]
 
 
-class MeshTanglingChecker_Base(abc.ABC):
+class MeshTanglingChecker:
     """
-    Base class for tracking whether a mesh has tangled, i.e. whether any of its elements
+    Class for tracking whether a mesh has tangled, i.e. whether any of its elements
     have become inverted.
     """
 
-    @abc.abstractmethod
-    def __init__(self, mesh, raise_error):
+    def __init__(self, mesh, raise_error=True):
         """
         :arg mesh: the mesh to track if tangled
         :type mesh: :class:`firedrake.mesh.MeshGeometry`
@@ -25,9 +23,11 @@ class MeshTanglingChecker_Base(abc.ABC):
         """
         self.mesh = mesh
         self.raise_error = raise_error
-        self.P0 = firedrake.FunctionSpace(mesh, "DG", 0)
-        self._sj = firedrake.Function(self.P0)
-        self._sj_expr = None
+        P0 = firedrake.FunctionSpace(mesh, "DG", 0)
+        self._sj = firedrake.Function(P0)
+        detJ = ufl.JacobianDeterminant(mesh)
+        s = firedrake.assemble(interpolate(ufl.sign(detJ), P0))
+        self._sj_expr = ufl.sign(detJ) / s
 
     @property
     def scaled_jacobian(self):
@@ -49,66 +49,3 @@ class MeshTanglingChecker_Base(abc.ABC):
                 raise ValueError(msg)
             warnings.warn(msg, stacklevel=1)
         return num_tangled
-
-
-class MeshTanglingChecker_1D(MeshTanglingChecker_Base):
-    """
-    Implementation of mesh tangling check in 1D.
-    """
-
-    def __init__(self, mesh, raise_error=True):
-        """
-        :arg mesh: the mesh to track if tangled
-        :type mesh: :class:`firedrake.mesh.MeshGeometry`
-        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
-            otherwise a warning is raised
-        :type raise_error: :class:`bool`
-        """
-        super().__init__(mesh, raise_error)
-        detJ = ufl.JacobianDeterminant(mesh)
-        s = firedrake.assemble(interpolate(ufl.sign(detJ), self.P0))
-        self._sj_expr = ufl.sign(detJ) / s
-
-
-class MeshTanglingChecker_2D(MeshTanglingChecker_Base):
-    """
-    Implementation of mesh tangling check in 2D.
-    """
-
-    def __init__(self, mesh, raise_error=True):
-        """
-        :arg mesh: the mesh to track if tangled
-        :type mesh: :class:`firedrake.mesh.MeshGeometry`
-        :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
-            otherwise a warning is raised
-        :type raise_error: :class:`bool`
-        """
-        super().__init__(mesh, raise_error)
-        detJ = ufl.JacobianDeterminant(mesh)
-        s = firedrake.assemble(interpolate(ufl.sign(detJ), self.P0))
-        self._sj_expr = ufl.sign(detJ) / s
-
-
-def MeshTanglingChecker(mesh, **kwargs):
-    """
-    Factory function for creating mesh tangling checker classes.
-
-    Note that the implementation is based on element orientations, so a reflection in
-    the :math:`x` coordinate (for example) will report mesh tangling, even though the
-    mesh doesn't 'look' tangled.
-
-    :arg mesh: the mesh to track if tangled
-    :type mesh: :class:`firedrake.mesh.MeshGeometry`
-    :kwarg raise_error: if ``True``, an error is raised if any element is tangled,
-        otherwise a warning is raised
-    :type raise_error: :class:`bool`
-    """
-    dim = mesh.topological_dimension()
-    try:
-        implementations = {
-            1: MeshTanglingChecker_1D,
-            2: MeshTanglingChecker_2D,
-        }
-        return implementations[dim](mesh, **kwargs)
-    except KeyError as ke:
-        raise ValueError(f"Mesh dimension {dim} not supported.") from ke

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -1,5 +1,6 @@
 import unittest
 
+import ufl
 from firedrake.utility_meshes import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
 
 from movement.tangling import MeshTanglingChecker
@@ -41,7 +42,18 @@ class TestTangling(unittest.TestCase):
         checker.mesh.coordinates.dat.data[3] += 0.2
         self.assertEqual(checker.check(), 1)
 
+    def test_2_tangled_elements_2d(self):
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
+        checker.mesh.coordinates.dat.data[3][0] += 0.5
+        self.assertEqual(checker.check(), 2)
+
     def test_3_tangled_elements_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
         checker.mesh.coordinates.dat.data[3] += 0.5
         self.assertEqual(checker.check(), 3)
+
+    def test_flip(self):
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
+        x, y = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, y]))
+        self.assertEqual(checker.check(), checker.mesh.num_cells())

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -11,15 +11,9 @@ class TestTangling(unittest.TestCase):
     Unit tests for mesh tangling checking.
     """
 
-    def test_dim_notimplementederror(self):
-        with self.assertRaises(ValueError) as cm:
-            MeshTanglingChecker(UnitCubeMesh(1, 1, 1))
-        msg = "Mesh dimension 3 not supported."
-        self.assertEqual(str(cm.exception), msg)
-
     def test_1_tangled_element_1d_error(self):
         checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=True)
-        checker.mesh.coordinates.dat.data[1] += 0.4
+        checker.mesh.coordinates.dat.data[1] += 0.4  # Vertex 1: (1/3)
         with self.assertRaises(ValueError) as cm:
             checker.check()
         self.assertEqual(str(cm.exception), "Mesh has 1 tangled element.")
@@ -27,33 +21,75 @@ class TestTangling(unittest.TestCase):
     def test_1_tangled_element_1d(self):
         checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=False)
         self.assertEqual(checker.check(), 0)
-        checker.mesh.coordinates.dat.data[1] += 0.4
+        checker.mesh.coordinates.dat.data[1] += 0.4  # Vertex 1: (1/3)
         self.assertEqual(checker.check(), 1)
 
     def test_2_tangled_elements_1d(self):
         checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=False)
-        checker.mesh.coordinates.dat.data[1] += 0.4
-        checker.mesh.coordinates.dat.data[3] -= 0.4
+        checker.mesh.coordinates.dat.data[1] += 0.4  # Vertex 1: (1/3)
+        checker.mesh.coordinates.dat.data[3] -= 0.4  # Vertex 3: (1)
         self.assertEqual(checker.check(), 2)
+
+    def test_flip_1d(self):
+        checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=False)
+        (x,) = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x]))
+        self.assertEqual(checker.check(), checker.mesh.num_cells())
 
     def test_1_tangled_element_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
         self.assertEqual(checker.check(), 0)
-        checker.mesh.coordinates.dat.data[3] += 0.2
+        checker.mesh.coordinates.dat.data[3] += 0.2  # Vertex 3: (1/3, 1/3)
         self.assertEqual(checker.check(), 1)
 
     def test_2_tangled_elements_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
-        checker.mesh.coordinates.dat.data[3][0] += 0.5
+        checker.mesh.coordinates.dat.data[3][0] += 0.5  # Vertex 3: (1/3, 1/3)
         self.assertEqual(checker.check(), 2)
 
     def test_3_tangled_elements_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
-        checker.mesh.coordinates.dat.data[3] += 0.5
+        checker.mesh.coordinates.dat.data[3] += 0.5  # Vertex 3: (1/3, 1/3)
         self.assertEqual(checker.check(), 3)
 
-    def test_flip(self):
+    def test_flip_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
         x, y = ufl.SpatialCoordinate(checker.mesh)
         checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, y]))
+        self.assertEqual(checker.check(), checker.mesh.num_cells())
+
+    def test_double_flip_2d(self):
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
+        x, y = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, 1 - y]))
+        self.assertEqual(checker.check(), 0)
+
+    def test_2_tangled_elements_3d(self):
+        checker = MeshTanglingChecker(UnitCubeMesh(3, 3, 3), raise_error=False)
+        self.assertEqual(checker.check(), 0)
+        checker.mesh.coordinates.dat.data[14][2] -= 0.4  # Vertex 14: (0, 0, 1)
+        self.assertEqual(checker.check(), 2)
+
+    def test_6_tangled_elements_3d(self):
+        checker = MeshTanglingChecker(UnitCubeMesh(3, 3, 3), raise_error=False)
+        self.assertEqual(checker.check(), 0)
+        checker.mesh.coordinates.dat.data[33][0] += (0.4,)  # Vertex 33: (1/3, 1/3, 1/3)
+        self.assertEqual(checker.check(), 6)
+
+    def test_flip_3d(self):
+        checker = MeshTanglingChecker(UnitCubeMesh(3, 3, 3), raise_error=False)
+        x, y, z = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, y, z]))
+        self.assertEqual(checker.check(), checker.mesh.num_cells())
+
+    def test_double_flip_3d(self):
+        checker = MeshTanglingChecker(UnitCubeMesh(3, 3, 3), raise_error=False)
+        x, y, z = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, 1 - y, z]))
+        self.assertEqual(checker.check(), 0)
+
+    def test_triple_flip_3d(self):
+        checker = MeshTanglingChecker(UnitCubeMesh(3, 3, 3), raise_error=False)
+        x, y, z = ufl.SpatialCoordinate(checker.mesh)
+        checker.mesh.coordinates.interpolate(ufl.as_vector([1 - x, 1 - y, 1 - z]))
         self.assertEqual(checker.check(), checker.mesh.num_cells())

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -11,9 +11,9 @@ class TestTangling(unittest.TestCase):
     """
 
     def test_dim_notimplementederror(self):
-        with self.assertRaises(NotImplementedError) as cm:
+        with self.assertRaises(ValueError) as cm:
             MeshTanglingChecker(UnitIntervalMesh(1))
-        msg = "Tangling check only currently supported in 2D."
+        msg = "Mesh dimension 1 not supported."
         self.assertEqual(str(cm.exception), msg)
 
     def test_tangling_checker_error1(self):
@@ -29,12 +29,6 @@ class TestTangling(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             checker.check()
         self.assertEqual(str(cm.exception), "Mesh has 3 tangled elements.")
-
-    def test_tangling_checker_dim_error(self):
-        with self.assertRaises(NotImplementedError) as cm:
-            MeshTanglingChecker(UnitIntervalMesh(1))
-        msg = "Tangling check only currently supported in 2D."
-        self.assertEqual(str(cm.exception), msg)
 
     def test_tangling_checker_warning1(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -1,6 +1,6 @@
 import unittest
 
-from firedrake.utility_meshes import UnitIntervalMesh, UnitSquareMesh
+from firedrake.utility_meshes import UnitCubeMesh, UnitIntervalMesh, UnitSquareMesh
 
 from movement.tangling import MeshTanglingChecker
 
@@ -12,26 +12,36 @@ class TestTangling(unittest.TestCase):
 
     def test_dim_notimplementederror(self):
         with self.assertRaises(ValueError) as cm:
-            MeshTanglingChecker(UnitIntervalMesh(1))
-        msg = "Mesh dimension 1 not supported."
+            MeshTanglingChecker(UnitCubeMesh(1, 1, 1))
+        msg = "Mesh dimension 3 not supported."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_tangling_checker_error1(self):
-        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=True)
-        checker.mesh.coordinates.dat.data[3] += 0.2
+    def test_1_tangled_element_1d_error(self):
+        checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=True)
+        checker.mesh.coordinates.dat.data[1] += 0.4
         with self.assertRaises(ValueError) as cm:
             checker.check()
         self.assertEqual(str(cm.exception), "Mesh has 1 tangled element.")
 
-    def test_tangling_checker_error2(self):
-        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=True)
-        checker.mesh.coordinates.dat.data[3] += 0.5
-        with self.assertRaises(ValueError) as cm:
-            checker.check()
-        self.assertEqual(str(cm.exception), "Mesh has 3 tangled elements.")
+    def test_1_tangled_element_1d(self):
+        checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=False)
+        self.assertEqual(checker.check(), 0)
+        checker.mesh.coordinates.dat.data[1] += 0.4
+        self.assertEqual(checker.check(), 1)
 
-    def test_tangling_checker_warning1(self):
+    def test_2_tangled_elements_1d(self):
+        checker = MeshTanglingChecker(UnitIntervalMesh(3), raise_error=False)
+        checker.mesh.coordinates.dat.data[1] += 0.4
+        checker.mesh.coordinates.dat.data[3] -= 0.4
+        self.assertEqual(checker.check(), 2)
+
+    def test_1_tangled_element_2d(self):
         checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
         self.assertEqual(checker.check(), 0)
         checker.mesh.coordinates.dat.data[3] += 0.2
         self.assertEqual(checker.check(), 1)
+
+    def test_3_tangled_elements_2d(self):
+        checker = MeshTanglingChecker(UnitSquareMesh(3, 3), raise_error=False)
+        checker.mesh.coordinates.dat.data[3] += 0.5
+        self.assertEqual(checker.check(), 3)


### PR DESCRIPTION
Closes #141.

This PR overhauls the tangling checking functionality:
* Simplify the implementation to just check for changes in the sign of the determinant of the Jacobian.
* This extends automatically to the 1D and 3D cases, as well as the already covered 2D case.
* Extend the test suite to cover other dimensions and cases.