### PR TITLE
Expand MA Helmholtz demo to interpolate soln field

### DIFF
--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -437,7 +437,7 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #    ========== ========= ==============
 #     Monitor    Error     CPU time (s)
 #    ========== ========= ==============
-#     monitor1   0.00596   3.16
+#     monitor    0.00596   3.16
 #     monitor2   0.00631   5.85
 #     monitor3   0.00871   5.98
 #     monitor4   0.00839   1.23

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -423,10 +423,9 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #
 #    L2-norm error on moved mesh: 0.008385305585746483
 #
-# The mesh movement step now only took 4 iterations to converge and each of those
-# iterations is now significantly faster. This resulted in a total runtime of only 1.23
+# The mesh movement step now only took 4 iterations, with a total runtime of only 1.23
 # seconds, which is up to five times shorter than previous examples. The final error is
-# again larger than the examples where the solution is recomputed at every iteration,
+# again larger than the example where the solution is recomputed at every iteration,
 # but is smaller than the example where we interpolated the solution field.
 #
 # We can summarise these results in the following table:

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -138,7 +138,7 @@ fig, axes = plt.subplots()
 #
 # Now we can construct a :class:`~movement.monge_ampere.MongeAmpereMover` instance to
 # adapt the mesh based on this monitor function. We will also time how long the mesh
-# movement step takes.
+# movement step takes to complete [#f1]_.
 
 import time
 
@@ -174,7 +174,7 @@ print(f"Time taken: {time.time() - t0:.2f} seconds")
 #      16   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 1.94e-07
 #      17   Volume ratio  1.15   Variation (σ/μ) 2.57e-02   Residual 5.86e-08
 #    Solver converged in 17 iterations.
-#    Time taken: 3.16 seconds
+#    Time taken: 2.52 seconds
 #
 # Plotting the resulting mesh:
 
@@ -263,7 +263,7 @@ print(f"Time taken: {time.time() - t0:.2f} seconds")
 #      18   Volume ratio  1.14   Variation (σ/μ) 2.37e-02   Residual 1.80e-07
 #      19   Volume ratio  1.14   Variation (σ/μ) 2.37e-02   Residual 9.21e-08
 #    Solver converged in 19 iterations.
-#    Time taken: 5.85 seconds
+#    Time taken: 6.17 seconds
 
 fig, axes = plt.subplots()
 triplot(mover.mesh, axes=axes)
@@ -338,7 +338,7 @@ print(f"Time taken: {time.time() - t0:.2f} seconds")
 #      23   Volume ratio  1.18   Variation (σ/μ) 1.80e-02   Residual 2.91e-07
 #      24   Volume ratio  1.18   Variation (σ/μ) 1.80e-02   Residual 1.88e-07
 #    Solver converged in 24 iterations.
-#    Time taken: 5.98 seconds
+#    Time taken: 6.19 seconds
 
 fig, axes = plt.subplots()
 triplot(mover.mesh, axes=axes)
@@ -404,7 +404,7 @@ print(f"Time taken: {time.time() - t0:.2f} seconds")
 #       3   Volume ratio  1.15   Variation (σ/μ) 2.11e-02   Residual 4.14e-05
 #       4   Volume ratio  1.15   Variation (σ/μ) 2.12e-02   Residual 4.80e-08
 #    Solver converged in 4 iterations.
-#    Time taken: 1.23 seconds
+#    Time taken: 1.09 seconds
 
 fig, axes = plt.subplots()
 triplot(mover.mesh, axes=axes)
@@ -423,7 +423,7 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #
 #    L2-norm error on moved mesh: 0.008385305585746483
 #
-# The mesh movement step now only took 4 iterations, with a total runtime of only 1.23
+# The mesh movement step now only took 4 iterations, with a total runtime of only 1.09
 # seconds, which is up to five times shorter than previous examples. The final error is
 # again larger than the example where the solution is recomputed at every iteration,
 # but is smaller than the example where we interpolated the solution field.
@@ -435,10 +435,10 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #    ============================ ========= ==============
 #     Monitor function             Error     CPU time (s)
 #    ============================ ========= ==============
-#     ``monitor_exact``            0.00596   3.16
-#     ``monitor_solve``            0.00631   5.85
-#     ``monitor_interp_soln``      0.00871   5.98
-#     ``monitor_interp_Hessian``   0.00839   1.23
+#     ``monitor_exact``            0.00596   2.52
+#     ``monitor_solve``            0.00631   6.17
+#     ``monitor_interp_soln``      0.00871   6.19
+#     ``monitor_interp_Hessian``   0.00839   1.09
 #    ============================ ========= ==============
 #
 # In this demo we demonstrated several examples of monitor functions and briefly
@@ -450,3 +450,10 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 # Movement allows and encourages such experimentation with different monitor functions.
 #
 # This tutorial can be dowloaded as a `Python script <monge_ampere_helmholtz.py>`__.
+#
+# .. rubric:: Footnotes
+#
+# .. [#f1] Running this script as it is will yield a slightly longer runtime of the
+#    first approach (3.14 seconds on our machine) due to the additional overhead of the
+#    first-time JIT compilation. The reported runtime of 2.52 seconds is obtained by
+#    running the first example twice in a row and taking the second runtime.

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -112,7 +112,7 @@ print("L2-norm error on initial mesh:", sqrt(assemble(dot(error, error) * dx)))
 alpha = Constant(5.0)
 
 
-def monitor(mesh):
+def monitor_exact(mesh):
     V = FunctionSpace(mesh, "CG", 1)
     Hnorm = Function(V, name="Hnorm")
     H = grad(grad(u_exact(mesh)))
@@ -126,7 +126,7 @@ def monitor(mesh):
 
 fig, axes = plt.subplots()
 m = Function(u_h, name="monitor")
-m.interpolate(monitor(mesh))
+m.interpolate(monitor_exact(mesh))
 contours = tripcolor(m, axes=axes)
 fig.colorbar(contours)
 plt.savefig("monge_ampere_helmholtz-monitor.jpg")
@@ -143,7 +143,7 @@ fig, axes = plt.subplots()
 import time
 
 rtol = 1.0e-08
-mover = MongeAmpereMover(mesh, monitor, method="quasi_newton", rtol=rtol)
+mover = MongeAmpereMover(mesh, monitor_exact, method="quasi_newton", rtol=rtol)
 
 t0 = time.time()
 mover.move()
@@ -220,7 +220,7 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 from animate import RiemannianMetric
 
 
-def monitor2(mesh):
+def monitor_solve(mesh):
     u_h = solve_helmholtz(mesh)
     V = FunctionSpace(mesh, "CG", 1)
     TV = TensorFunctionSpace(mesh, "CG", 1)
@@ -234,7 +234,7 @@ def monitor2(mesh):
     return m
 
 
-mover = MongeAmpereMover(mesh, monitor2, method="quasi_newton", rtol=rtol)
+mover = MongeAmpereMover(mesh, monitor_solve, method="quasi_newton", rtol=rtol)
 
 t0 = time.time()
 mover.move()
@@ -292,7 +292,7 @@ t0 = time.time()
 u_h = solve_helmholtz(mesh)
 
 
-def monitor3(mesh):
+def monitor_interp_soln(mesh):
     V = FunctionSpace(mesh, "CG", 1)
     u_h_interp = Function(V).interpolate(u_h)
     TV = TensorFunctionSpace(mesh, "CG", 1)
@@ -306,7 +306,7 @@ def monitor3(mesh):
     return m
 
 
-mover = MongeAmpereMover(mesh, monitor3, method="quasi_newton", rtol=rtol)
+mover = MongeAmpereMover(mesh, monitor_interp_soln, method="quasi_newton", rtol=rtol)
 mover.move()
 print(f"Time taken: {time.time() - t0:.2f} seconds")
 
@@ -380,7 +380,7 @@ H = RiemannianMetric(TV)
 H.compute_hessian(u_h, method="L2")
 
 
-def monitor4(mesh):
+def monitor_interp_Hessian(mesh):
     V = FunctionSpace(mesh, "CG", 1)
     TV = TensorFunctionSpace(mesh, "CG", 1)
     H_interp = RiemannianMetric(TV).interpolate(H)
@@ -392,7 +392,7 @@ def monitor4(mesh):
     return m
 
 
-mover = MongeAmpereMover(mesh, monitor4, method="quasi_newton", rtol=rtol)
+mover = MongeAmpereMover(mesh, monitor_interp_Hessian, method="quasi_newton", rtol=rtol)
 mover.move()
 print(f"Time taken: {time.time() - t0:.2f} seconds")
 
@@ -434,14 +434,14 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #
 # .. table::
 #
-#    ========== ========= ==============
-#     Monitor    Error     CPU time (s)
-#    ========== ========= ==============
-#     monitor    0.00596   3.16
-#     monitor2   0.00631   5.85
-#     monitor3   0.00871   5.98
-#     monitor4   0.00839   1.23
-#    ========== ========= ==============
+#    ======================== ========= ==============
+#     Monitor function         Error     CPU time (s)
+#    ======================== ========= ==============
+#     monitor_exact            0.00596   3.16
+#     monitor_solve            0.00631   5.85
+#     monitor_interp_soln      0.00871   5.98
+#     monitor_interp_Hessian   0.00839   1.23
+#    ======================== ========= ==============
 #
 # In this demo we demonstrated several examples of monitor functions and briefly
 # evaluated their performance. Each approach has inherent advantages and limitations

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -434,14 +434,14 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #
 # .. table::
 #
-#    ======================== ========= ==============
-#     Monitor function         Error     CPU time (s)
-#    ======================== ========= ==============
-#     monitor_exact            0.00596   3.16
-#     monitor_solve            0.00631   5.85
-#     monitor_interp_soln      0.00871   5.98
-#     monitor_interp_Hessian   0.00839   1.23
-#    ======================== ========= ==============
+#    ============================ ========= ==============
+#     Monitor function             Error     CPU time (s)
+#    ============================ ========= ==============
+#     ``monitor_exact``            0.00596   3.16
+#     ``monitor_solve``            0.00631   5.85
+#     ``monitor_interp_soln``      0.00871   5.98
+#     ``monitor_interp_Hessian``   0.00839   1.23
+#    ============================ ========= ==============
 #
 # In this demo we demonstrated several examples of monitor functions and briefly
 # evaluated their performance. Each approach has inherent advantages and limitations

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -424,11 +424,10 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #    L2-norm error on moved mesh: 0.008385305585746483
 #
 # The mesh movement step now only took 4 iterations to converge and each of those
-# iterations is over an order of magnitude faster than those in previous examples.
-# The final error is again larger than the examples where the solution is
-# recomputed at every iteration, but is smaller than the example where we
-# interpolated the solution field. The largest gain is in the total runtime, which is
-# up to five times shorter than previous examples.
+# iterations is now significantly faster. This resulted in a total runtime of only 1.23
+# seconds, which is up to five times shorter than previous examples. The final error is
+# again larger than the examples where the solution is recomputed at every iteration,
+# but is smaller than the example where we interpolated the solution field.
 #
 # We can summarise these results in the following table:
 #

--- a/demos/monge_ampere_helmholtz.py
+++ b/demos/monge_ampere_helmholtz.py
@@ -340,7 +340,14 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 #
 #    L2-norm error on moved mesh: 0.008712487462902048
 #
-# TEMP: Now interpolate the Hessian
+# Even though the number of iterations has increased (24 compared to 17 and 19),
+# each iteration is significantly cheaper since the PDE is not solved again every
+# time. However, we observe that this also lead to a significantly larger error.
+#
+# We may further speed up the mesh movement step by also avoiding recomputing
+# the Hessian at every iteration. Similarly to the above example, we compute the
+# solution on the initial (uniform) mesh, but now we also compute its Hessian and
+# interpolate the Hessian onto adapted meshes.
 
 u_h = solve_helmholtz(mesh)
 TV = TensorFunctionSpace(mesh, "CG", 1)
@@ -388,5 +395,19 @@ print("L2-norm error on moved mesh:", sqrt(assemble(dot(error, error) * dx)))
 # .. code-block:: none
 #
 #    L2-norm error on moved mesh: 0.008385305585746483
+#
+# The mesh movement step now only took 4 iterations to converge and each of those
+# iterations is over an order of magnitude faster than those in previous examples.
+# The final error is again larger than the examples where the solution is
+# recomputed at every iteration, but is smaller than the example where we
+# interpolated the solution field.
+#
+# In this demo we demonstrated several examples of monitor functions and briefly
+# evaluated their performance. Each approach has inherent advantages and limitations
+# which should be considered for every new problem of interest. PDEs that are highly
+# sensitive to changes in local resolution may require recomputing the solution at
+# every iteration. In other cases we may obtain adequate results by defining a monitor
+# function that computes the solution less frequently, or even only once per iteration.
+# Movement allows and encourages such experimentation with different monitor functions.
 #
 # This tutorial can be dowloaded as a `Python script <monge_ampere_helmholtz.py>`__.


### PR DESCRIPTION
Closes #27.

@jwallwork23 I added a monitor function `monitor3` that computes the solution only once and interpolates it, as we discussed today. I also added `monitor4` that instead interpolates the Hessian field - which is then much faster. I'm not sure if that's good practice in general so I labelled it as TEMP, but it looks good in this case. Will delete/expand it based on what you say :)

I was also thinking... would it make sense to compute the solution every $n$ iterations, instead of only once or every time as we currently show in the demo?