### PR TITLE
Switch to comp coords before moving with QN

### DIFF
--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -728,6 +728,7 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
         # Solve equidistribution problem, handling convergence errors according to
         # desired behaviour
         try:
+            self.to_computational_coordinates()
             self.equidistributor.solve()
             self._convergence_message(self.snes.getIterationNumber())
         except fexc.ConvergenceError as conv_err:

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -725,10 +725,12 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
         :return: the iteration count
         :rtype: :class:`int`
         """
+        # Switch to computational coordinates
+        self.to_computational_coordinates()
+
         # Solve equidistribution problem, handling convergence errors according to
         # desired behaviour
         try:
-            self.to_computational_coordinates()
             self.equidistributor.solve()
             self._convergence_message(self.snes.getIterationNumber())
         except fexc.ConvergenceError as conv_err:


### PR DESCRIPTION
Closes #146.

I think only this was needed. Using `method="relaxation"` works as expected