### PR TITLE
Fix PETSc errors in CI

### DIFF
--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -577,6 +577,10 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
         :kwarg dtol: divergence tolerance for the residual
         :type dtol: :class:`float`
         """
+        if mesh.topological_dimension() == 1:
+            raise NotImplementedError(
+                "1D case not implemented for quasi-Newton method."
+            )
         super().__init__(mesh, monitor_function=monitor_function, **kwargs)
 
         # Initialise phi and H

--- a/movement/monge_ampere.py
+++ b/movement/monge_ampere.py
@@ -9,6 +9,7 @@ import firedrake
 import firedrake.exceptions as fexc
 import numpy as np
 import ufl
+from animate.utility import function2cofunction
 from firedrake.petsc import PETSc
 from pyadjoint import no_annotations
 
@@ -503,7 +504,7 @@ class MongeAmpereMover_Relaxation(MongeAmpereMover_Base):
             # Update monitor function
             self.to_physical_coordinates()
             self.monitor.interpolate(self.monitor_function(self.mesh))
-            firedrake.assemble(self.L_P0, tensor=self.volume)
+            firedrake.assemble(self.L_P0, tensor=function2cofunction(self.volume))
             self.volume.interpolate(self.volume / self.original_volume)
             self.to_computational_coordinates()
 
@@ -703,7 +704,7 @@ class MongeAmpereMover_QuasiNewton(MongeAmpereMover_Base):
             cursol = snes.getSolution()
             update_monitor(cursol)
             self.to_physical_coordinates()
-            firedrake.assemble(self.L_P0, tensor=self.volume)
+            firedrake.assemble(self.L_P0, tensor=function2cofunction(self.volume))
             self.volume.interpolate(self.volume / self.original_volume)
             self.to_computational_coordinates()
             PETSc.Sys.Print(

--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -479,7 +479,6 @@ class TestMisc(BaseClasses.TestMongeAmpere):
     @parameterized.expand(
         [
             (1, "relaxation"),
-            (1, "quasi_newton"),
             (2, "relaxation"),
             (2, "quasi_newton"),
             (3, "relaxation"),

--- a/test/test_monge_ampere.py
+++ b/test/test_monge_ampere.py
@@ -68,6 +68,13 @@ class TestExceptions(BaseClasses.TestMongeAmpere):
             MongeAmpereMover(self.dummy_mesh, None)
         self.assertEqual(str(cm.exception), "Please supply a monitor function.")
 
+    def test_1d_quasi_newton_valueerror(self):
+        mesh = self.mesh(dim=1)
+        with self.assertRaises(NotImplementedError) as cm:
+            MongeAmpereMover(mesh, self.dummy_monitor, method="quasi_newton")
+        msg = "1D case not implemented for quasi-Newton method."
+        self.assertEqual(str(cm.exception), msg)
+
     @parameterized.expand([("relaxation"), ("quasi_newton")])
     def test_maxiter_convergenceerror(self, method):
         """
@@ -167,7 +174,6 @@ class TestMonitor(BaseClasses.TestMongeAmpere):
     @parameterized.expand(
         [
             (1, "relaxation"),
-            (1, "quasi_newton"),
             (2, "relaxation"),
             (2, "quasi_newton"),
             (3, "relaxation"),
@@ -281,7 +287,6 @@ class TestBCs(BaseClasses.TestMongeAmpere):
     @parameterized.expand(
         [
             (1, "relaxation"),
-            (1, "quasi_newton"),
             (2, "relaxation"),
             (2, "quasi_newton"),
             (3, "relaxation"),
@@ -317,9 +322,6 @@ class TestBCs(BaseClasses.TestMongeAmpere):
             (1, "relaxation", "on_boundary"),
             (1, "relaxation", [1]),
             (1, "relaxation", []),
-            (1, "quasi_newton", "on_boundary"),
-            (1, "quasi_newton", [1]),
-            (1, "quasi_newton", []),
             (2, "relaxation", "on_boundary"),
             (2, "relaxation", [1]),
             (2, "relaxation", []),
@@ -443,7 +445,6 @@ class TestMisc(BaseClasses.TestMongeAmpere):
     @parameterized.expand(
         [
             (1, "relaxation"),
-            (1, "quasi_newton"),
             (2, "relaxation"),
             (2, "quasi_newton"),
             (3, "relaxation"),


### PR DESCRIPTION
Closes #151.

This PR addresses two issues that cropped up with recent Firedrake updates:
* Assembling a 1-form to a tensor now requires the tensor to be represented as a `Cofunction`.
* The Quasi-Newton solver no longer works in 1D. Looking more closely, I'm surprised it ever did. It uses a vector space basis that accesses `sub(1)`, which doesn't exist in 1D. I think it's best to just drop support for the QN approach in 1D, as done here.