### PR TITLE
Add missing matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools"]
+requires = [
+  "matplotlib",
+  "setuptools",
+]
 
 [project]
 name = "movement"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-  "matplotlib",
-  "setuptools",
-]
+requires = ["setuptools"]
 
 [project]
 name = "movement"
@@ -27,6 +24,7 @@ classifiers = [
 	"Programming Language :: Python",
 ]
 dependencies = [
+  "matplotlib",
   "sympy",
   "vtk",
 ]


### PR DESCRIPTION
Regular Movement CI is failing
https://github.com/mesh-adaptation/movement/actions/runs/13743718607

Looks like we're missing a matplotlib dependency as well.