### PR TITLE
Use Firedrake vanilla in CI

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -64,5 +64,4 @@ jobs:
           python3 $(which firedrake-clean)
           python3 -m coverage erase
           python3 -m coverage run --source=movement -m pytest -v test
-          python3 -m coverage combine
           python3 -m coverage report -m


### PR DESCRIPTION
Closes #164
Merges into #166

Movement doesn't need Firedrake to be built with Mmg and ParMmg, it just needs to install Animate for some utilities, e.g., Hessian recovery. As such, we can revert to just using the vanilla Firedrake Docker image and pip install Animate as part of the CI.